### PR TITLE
Add a killSignal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ The time in seconds before the task times out if `startCheck` has not yet return
 
 Setting this to `false` disables the timeout.
 
+### killSignal
+Type: `string`
+Default: `SIGTERM`
+
+The signal sent to the process to kill it.
+
 ### Usage Examples
 
 Launch a CouchDB instance and wait for it to fully boot.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ Default: `SIGTERM`
 
 The signal sent to the process to kill it.
 
+### stdout
+Type: `fd`
+Default: `undefined`
+
+An open file descriptor to write stdout of the daemon process to.
+
+### stderr
+Type: `fd`
+Default: `undefined`
+
+An open file descriptor to write stderr of the daemon process to. Can be the same stream as `options.stdout`.
+
 ### Usage Examples
 
 Launch a CouchDB instance and wait for it to fully boot.

--- a/tasks/external_daemon.js
+++ b/tasks/external_daemon.js
@@ -64,6 +64,11 @@
       grunt.verbose.write(util.format("[%s STDOUT] %s"), cmd, result.stdout);
       grunt.verbose.write(util.format("[%s STDERR] %s"), cmd, result.stderr);
 
+      if (typeof options.stdout === 'number')
+        fs.closeSync(options.stdout)
+      if (typeof options.stderr === 'number' && options.stderr !== options.stdout)
+        fs.closeSync(options.stderr);
+
       grunt.log.warn(util.format("Command %s exited with status code %s", cmd, code));
     });
 
@@ -73,10 +78,20 @@
     proc.stdout.on('data', function(data) {
       stdout.push(data);
       logFunc(util.format("[%s STDOUT] %s", cmd, data));
+
+      if (typeof options.stdout === 'number') {
+        var buf = new Buffer(data);
+        fs.writeSync(options.stdout, buf, 0, buf.length);
+      }
     });
     proc.stderr.on('data', function(data) {
       stderr.push(data);
       logFunc(util.format("[%s STDERR] %s", cmd, data));
+
+      if (typeof options.stderr === 'number') {
+        var buf = new Buffer(data);
+        fs.writeSync(options.stderr, buf, 0, buf.length);
+      }
     });
 
     grunt.event.on(startedEventName, function() {

--- a/tasks/external_daemon.js
+++ b/tasks/external_daemon.js
@@ -22,7 +22,8 @@
       nodeSpawnOptions: {},
       startCheck: function() { return true; },
       startCheckInterval: 0.5,
-      startCheckTimeout: 3.0
+      startCheckTimeout: 3.0,
+      killSignal: 'SIGTERM'
     });
     var name = this.target;
     var cmd = this.data.cmd;
@@ -32,10 +33,10 @@
         failTimeoutTime   = (options.startCheckTimeout * 1000);
     var logFunc = (options.verbose) ? grunt.log.write : grunt.verbose.write;
     var proc, failTimeoutHandle, checkIntervalHandle, stdout = [], stderr = [];
-    var handleSig = function () { proc.kill(); done(); };
+    var handleSig = function () { proc.kill(options.killSignal); done(); };
 
     // Make sure we don't leave behind any dangling processes.
-    process.on('exit', function() { proc.kill(); });
+    process.on('exit', function() { proc.kill(options.killSignal); });
     process.on('SIGTERM', handleSig);
     process.on('SIGHUP', handleSig);
     process.on('SIGINT', handleSig);


### PR DESCRIPTION
Some services, like Ruby Rackup servers, handle SIGTERM and don't die. In the case of Rackup, we need to send a SIGINT. This allows for setting the signal used.
